### PR TITLE
Fix: Prevent button layout issue with large fonts (#5)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -141,29 +141,22 @@ const Appl: React.FC = () => {
         <IonTabBar slot="bottom">
           <IonTabButton tab="tab1" href="/connect">
             <IonIcon aria-hidden="true" icon={bluetooth} />
-            <IonLabel>connect</IonLabel>
           </IonTabButton>
           <IonTabButton tab="tab2" href="/settings">
             <IonIcon aria-hidden="true" icon={settings} />
-            <IonLabel>settings</IonLabel>
           </IonTabButton>
           <IonTabButton tab="info" href="/info">
             <IonIcon aria-hidden="true" icon={informationCircleOutline} />
-            <IonLabel>Info</IonLabel>
           </IonTabButton>
           <IonTabButton tab="tab3" href="/chat">
             <IonIcon aria-hidden="true" icon={chatboxEllipses} />
-            <IonLabel>chat</IonLabel>
           </IonTabButton>
           <IonTabButton tab="map" href="/map">
             <IonIcon aria-hidden="true" icon={globe} />
-            <IonLabel>Map</IonLabel>
           </IonTabButton>
           <IonTabButton tab="mheard" href="/mheard">
             <IonIcon aria-hidden="true" icon={move} />
-            <IonLabel>Mheard</IonLabel>
           </IonTabButton>
-          
         </IonTabBar>
       </IonTabs>
     </IonReactRouter>


### PR DESCRIPTION
Removing the text below the buttons ensures they keep a fixed size. Previously, increasing the Android system font size caused the "Mheard" and "Connect" buttons to be cut off or disappear.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/26cc6903-969e-4276-b981-7a27a6b98856"/></td>
    <td><img src="https://github.com/user-attachments/assets/6e2d6ffa-eaf5-424f-91b8-a1c52ead98d7"/></td>
  </tr>
</table>